### PR TITLE
Update MITRE ID for VIM-CMD Delete VM Snapshots Technique

### DIFF
--- a/_lolesxi/Binaries/vim-cmd.md
+++ b/_lolesxi/Binaries/vim-cmd.md
@@ -42,7 +42,7 @@ Commands:
     Usecase: Deletes all snapshots of all Virtual Machines. This activity is usually observed near ransomware deployment and is often executed programatically.
     Category: Inhibit Recovery
     Privileges: Administrator
-    MitreID: T1485.001
+    MitreID: T1485
     OperatingSystem: ESXi
     ProceduralExamples:
      - for i in `vim-cmd vmsvc/getallvms| awk '{print$1}'`;do vim-cmd vmsvc/snapshot.removeall $i & done

--- a/_lolesxi/Binaries/vim-cmd.md
+++ b/_lolesxi/Binaries/vim-cmd.md
@@ -42,7 +42,7 @@ Commands:
     Usecase: Deletes all snapshots of all Virtual Machines. This activity is usually observed near ransomware deployment and is often executed programatically.
     Category: Inhibit Recovery
     Privileges: Administrator
-    MitreID: T1082
+    MitreID: T1485.001
     OperatingSystem: ESXi
     ProceduralExamples:
      - for i in `vim-cmd vmsvc/getallvms| awk '{print$1}'`;do vim-cmd vmsvc/snapshot.removeall $i & done


### PR DESCRIPTION
Update MITRE ID for Delete VM Snapshot technique. It was previously `T1082` when it should be `T1485`. See https://attack.mitre.org/techniques/T1485 for reference