### PR TITLE
Add Firewall Default Action Set to PASS ESXCLI Command & Add Modify Service Category

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -47,7 +47,7 @@
   * `ProceduralExamples` (Additional command examples observed via CTI);
   * `Description` (details of the 'lol' command behavior);
   * `Usecase` (details of the use case such as the purpose and technique;
-  * `Category` (LOLESXi categories include Terminate Process,Lists VMs,Terminate Running VM,System Information,Account Enumeration,Find Files,Remove Evidence,Find and Replace,Change File Permission,Discover storage,Enable Service,Disable Startup,Inhibit Recovery,Power off VM,Stop Service,Adjust Performance,Replace File,Timestomp,Change Display Information,Disable Service,Discover Network Info,Software Operation);
+  * `Category` (LOLESXi categories include Terminate Process,Lists VMs,Terminate Running VM,System Information,Account Enumeration,Find Files,Remove Evidence,Find and Replace,Change File Permission,Discover storage,Enable Service,Disable Startup,Inhibit Recovery,Power off VM,Stop Service,Adjust Performance,Replace File,Timestomp,Change Display Information,Disable Service, Modify Service, Discover Network Info,Software Operation);
   * `Privilege` (User or Administrator level privileges required);
   * `MitreId`[^1] (MITRE (R) ATT&CK(R) Tactic/Technique mapping);
   * `OperatingSystem` (version of ESXi if known).

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Interesting functionality can include:
 * Timestomp
 * Change Display Information
 * Disable Service
+* Modify Service
 * Discover Network Info
 * Software Operation
 

--- a/_data/functions.yml
+++ b/_data/functions.yml
@@ -109,7 +109,7 @@ software operation:
   description: |
     Installs VIB a vSphere Installation Bundle or modifies VIB acceptance levels.
 
-modify_service:
+modify service:
   label: Modify Service
   description: |
     Modifies a service potentially impacting functionality.

--- a/_data/functions.yml
+++ b/_data/functions.yml
@@ -108,3 +108,8 @@ software operation:
   label: Software Operation
   description: |
     Installs VIB a vSphere Installation Bundle or modifies VIB acceptance levels.
+
+modify_service:
+  label: Modify Service
+  description: |
+    Modifies a service potentially impacting functionality.

--- a/_lolesxi/Binaries/esxcli.md
+++ b/_lolesxi/Binaries/esxcli.md
@@ -67,14 +67,14 @@ Commands:
   - Command: esxcli network firewall set --enabled false
     Description: Disables the ESXi firewall.
     Usecase: An adversary changes the ESXi host based firewall so it will cause minimum interference with their operations.
-    Category: disable service
+    Category: disable or modify service
     Privileges: Administrator
     MitreID: T1562.004
     OperatingSystem: ESXi
   - Command: esxcli network firewall set --default-action true
     Description: Changes the ESXi firewall default action to PASS. Command is inferred based on vendor documentation, not available via CTI.
     Usecase: An adversary sets the default firewall action to pass allowing them to bypass any configured rules.
-    Category: disable service
+    Category: disable or modify service
     Privileges: Administrator
     MitreID: T1562.004
     OperatingSystem: ESXi

--- a/_lolesxi/Binaries/esxcli.md
+++ b/_lolesxi/Binaries/esxcli.md
@@ -72,7 +72,7 @@ Commands:
     MitreID: T1562.004
     OperatingSystem: ESXi
   - Command: esxcli network firewall set --default-action true
-    Description: Changes the ESXi firewall default action to PASS.
+    Description: Changes the ESXi firewall default action to PASS. Command is inferred based on vendor documentation, not available via CTI.
     Usecase: An adversary sets the default firewall action to pass allowing them to bypass any configured rules.
     Category: disable service
     Privileges: Administrator
@@ -180,6 +180,7 @@ Resources:
   - Link: https://www.forescout.com/resources/rise-in-linux-ransomware/
   - Link: https://www.reversinglabs.com/blog/gwisinlocker-ransomware-targets-south-korean-industrial-and-pharmaceutical-companies
   - Link: https://developer.broadcom.com/xapis/esxcli-command-reference/7.0.0/
+  - Link: https://cloud.google.com/blog/topics/threat-intelligence/vmware-detection-containment-hardening
 Acknowledgement:
   - Person: Michael Dawson
   - Person: Junestherry Dela Cruz

--- a/_lolesxi/Binaries/esxcli.md
+++ b/_lolesxi/Binaries/esxcli.md
@@ -72,14 +72,14 @@ Commands:
     MitreID: T1562.004
     OperatingSystem: ESXi
   - Command: esxcli network firewall set --default-action true
-      Description: Changes the firewall default action to PASS.
-      Usecase: Changing the default firewall action to PASS effectively disables it.
-      Category: disable service
-      Privileges: Administrator
-      MitreID: T1562.004
-      OperatingSystem: ESXi
-      ProceduralExamples:
-        - esxcli network firewall set -d true
+    Description: Changes the firewall default action to PASS.
+    Usecase: Changing the default firewall action to PASS effectively disables it.
+    Category: disable service
+    Privileges: Administrator
+    MitreID: T1562.004
+    OperatingSystem: ESXi
+    ProceduralExamples:
+      - esxcli network firewall set -d true
   - Command: esxcli vsan debug vmdk list
     Description: List the status of VMDKs in vSAN.
     Usecase: An adversary carries out enumeration of storage.

--- a/_lolesxi/Binaries/esxcli.md
+++ b/_lolesxi/Binaries/esxcli.md
@@ -72,8 +72,8 @@ Commands:
     MitreID: T1562.004
     OperatingSystem: ESXi
   - Command: esxcli network firewall set --default-action true
-    Description: Changes the firewall default action to PASS.
-    Usecase: Changing the default firewall action to PASS effectively disables it.
+    Description: Changes the ESXi firewall default action to PASS.
+    Usecase: An adversary sets the default firewall action to pass allowing them to bypass any configured rules.
     Category: disable service
     Privileges: Administrator
     MitreID: T1562.004
@@ -179,6 +179,7 @@ Resources:
   - Link: https://www.hybrid-analysis.com/sample/be5d2e94c2498ec052fb025e3348085e418c856dd43080501acfe2067ba54c41/6553b8f44c06e50d5408581f
   - Link: https://www.forescout.com/resources/rise-in-linux-ransomware/
   - Link: https://www.reversinglabs.com/blog/gwisinlocker-ransomware-targets-south-korean-industrial-and-pharmaceutical-companies
+  - Link: https://developer.broadcom.com/xapis/esxcli-command-reference/7.0.0/
 Acknowledgement:
   - Person: Michael Dawson
   - Person: Junestherry Dela Cruz

--- a/_lolesxi/Binaries/esxcli.md
+++ b/_lolesxi/Binaries/esxcli.md
@@ -73,7 +73,7 @@ Commands:
     OperatingSystem: ESXi
   - Command: esxcli network firewall set --default-action true
     Description: Changes the ESXi firewall default action to PASS. Command is inferred based on vendor documentation, not available via CTI.
-    Usecase: An adversary sets the default firewall action to pass allowing them to bypass any configured rules.
+    Usecase: An adversary sets the default firewall action to allow all incoming and outgoing traffic.
     Category: modify service
     Privileges: Administrator
     MitreID: T1562.004

--- a/_lolesxi/Binaries/esxcli.md
+++ b/_lolesxi/Binaries/esxcli.md
@@ -71,6 +71,15 @@ Commands:
     Privileges: Administrator
     MitreID: T1562.004
     OperatingSystem: ESXi
+  - Command: esxcli network firewall set --default-action true
+      Description: Changes the firewall default action to PASS.
+      Usecase: Changing the default firewall action to PASS effectively disables it.
+      Category: disable service
+      Privileges: Administrator
+      MitreID: T1562.004
+      OperatingSystem: ESXi
+      ProceduralExamples:
+        - esxcli network firewall set -d true
   - Command: esxcli vsan debug vmdk list
     Description: List the status of VMDKs in vSAN.
     Usecase: An adversary carries out enumeration of storage.

--- a/_lolesxi/Binaries/esxcli.md
+++ b/_lolesxi/Binaries/esxcli.md
@@ -67,14 +67,14 @@ Commands:
   - Command: esxcli network firewall set --enabled false
     Description: Disables the ESXi firewall.
     Usecase: An adversary changes the ESXi host based firewall so it will cause minimum interference with their operations.
-    Category: disable or modify service
+    Category: disable service
     Privileges: Administrator
     MitreID: T1562.004
     OperatingSystem: ESXi
   - Command: esxcli network firewall set --default-action true
     Description: Changes the ESXi firewall default action to PASS. Command is inferred based on vendor documentation, not available via CTI.
     Usecase: An adversary sets the default firewall action to pass allowing them to bypass any configured rules.
-    Category: disable or modify service
+    Category: modify service
     Privileges: Administrator
     MitreID: T1562.004
     OperatingSystem: ESXi


### PR DESCRIPTION
This PR adds a new esxcli command that modifies the ESXi firewall default action to PASS traffic instead of DROP, essentially disabling the firewall. It also adds a new category "Modify Service" since this command doesn't disable a service.

Fixes #18 

Branch can be viewed at https://nburns.tech/LOLESXi/lolesxi/Binaries/esxcli/